### PR TITLE
Add TeacherQuestionForm for creating questions

### DIFF
--- a/EduLms.WinForms/TeacherQuestionForm.Designer.cs
+++ b/EduLms.WinForms/TeacherQuestionForm.Designer.cs
@@ -1,0 +1,103 @@
+namespace EduLms.WinForms
+{
+    partial class TeacherQuestionForm
+    {
+        private System.ComponentModel.IContainer components = null;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        private void InitializeComponent()
+        {
+            cmbSubjects = new ComboBox();
+            txtQuestion = new TextBox();
+            numDifficulty = new NumericUpDown();
+            gridOptions = new DataGridView();
+            btnSave = new Button();
+            var colContent = new DataGridViewTextBoxColumn();
+            var colIsCorrect = new DataGridViewCheckBoxColumn();
+            ((System.ComponentModel.ISupportInitialize)numDifficulty).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)gridOptions).BeginInit();
+            SuspendLayout();
+            //
+            // cmbSubjects
+            //
+            cmbSubjects.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbSubjects.Location = new Point(30, 25);
+            cmbSubjects.Name = "cmbSubjects";
+            cmbSubjects.Size = new Size(200, 23);
+            cmbSubjects.TabIndex = 0;
+            //
+            // txtQuestion
+            //
+            txtQuestion.Location = new Point(30, 65);
+            txtQuestion.Multiline = true;
+            txtQuestion.Name = "txtQuestion";
+            txtQuestion.Size = new Size(400, 60);
+            txtQuestion.TabIndex = 1;
+            //
+            // numDifficulty
+            //
+            numDifficulty.Location = new Point(250, 25);
+            numDifficulty.Name = "numDifficulty";
+            numDifficulty.Size = new Size(120, 23);
+            numDifficulty.TabIndex = 2;
+            //
+            // gridOptions
+            //
+            colContent.HeaderText = "Option";
+            colContent.Name = "colContent";
+            colIsCorrect.HeaderText = "IsCorrect";
+            colIsCorrect.Name = "colIsCorrect";
+            gridOptions.Columns.AddRange(new DataGridViewColumn[] { colContent, colIsCorrect });
+            gridOptions.Location = new Point(30, 140);
+            gridOptions.Name = "gridOptions";
+            gridOptions.Size = new Size(400, 150);
+            gridOptions.TabIndex = 3;
+            //
+            // btnSave
+            //
+            btnSave.Location = new Point(355, 310);
+            btnSave.Name = "btnSave";
+            btnSave.Size = new Size(75, 23);
+            btnSave.TabIndex = 4;
+            btnSave.Text = "Save";
+            btnSave.UseVisualStyleBackColor = true;
+            btnSave.Click += btnSave_Click;
+            //
+            // TeacherQuestionForm
+            //
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            ClientSize = new Size(464, 351);
+            Controls.Add(btnSave);
+            Controls.Add(gridOptions);
+            Controls.Add(numDifficulty);
+            Controls.Add(txtQuestion);
+            Controls.Add(cmbSubjects);
+            Name = "TeacherQuestionForm";
+            Text = "TeacherQuestionForm";
+            Load += TeacherQuestionForm_Load;
+            ((System.ComponentModel.ISupportInitialize)numDifficulty).EndInit();
+            ((System.ComponentModel.ISupportInitialize)gridOptions).EndInit();
+            ResumeLayout(false);
+            PerformLayout();
+        }
+
+        #endregion
+
+        private ComboBox cmbSubjects;
+        private TextBox txtQuestion;
+        private NumericUpDown numDifficulty;
+        private DataGridView gridOptions;
+        private Button btnSave;
+    }
+}

--- a/EduLms.WinForms/TeacherQuestionForm.cs
+++ b/EduLms.WinForms/TeacherQuestionForm.cs
@@ -1,0 +1,77 @@
+using EduLms.Data.Data.Models;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace EduLms.WinForms
+{
+    public partial class TeacherQuestionForm : Form
+    {
+        private readonly EduLmsContext _db;
+        public TeacherQuestionForm(EduLmsContext db)
+        {
+            InitializeComponent();
+            _db = db;
+        }
+
+        private async void TeacherQuestionForm_Load(object sender, EventArgs e)
+        {
+            var subjects = await _db.Subjects.AsNoTracking().ToListAsync();
+            cmbSubjects.DataSource = subjects;
+            cmbSubjects.DisplayMember = nameof(Subject.SubjectName);
+            cmbSubjects.ValueMember = nameof(Subject.SubjectId);
+        }
+
+        private async void btnSave_Click(object sender, EventArgs e)
+        {
+            if (cmbSubjects.SelectedItem is not Subject subject)
+            {
+                MessageBox.Show("Please select a subject.");
+                return;
+            }
+            if (string.IsNullOrWhiteSpace(txtQuestion.Text))
+            {
+                MessageBox.Show("Question text is required.");
+                return;
+            }
+
+            var options = new List<Option>();
+            foreach (DataGridViewRow row in gridOptions.Rows)
+            {
+                if (row.IsNewRow) continue;
+                var content = row.Cells["colContent"].Value?.ToString();
+                var isCorrectObj = row.Cells["colIsCorrect"].Value;
+                var isCorrect = isCorrectObj != null && (bool)isCorrectObj;
+                if (string.IsNullOrWhiteSpace(content))
+                {
+                    MessageBox.Show("All option texts are required.");
+                    return;
+                }
+                options.Add(new Option { Content = content, IsCorrect = isCorrect });
+            }
+
+            if (!options.Any(o => o.IsCorrect))
+            {
+                MessageBox.Show("At least one option must be marked correct.");
+                return;
+            }
+
+            var question = new Question
+            {
+                SubjectId = subject.SubjectId,
+                Content = txtQuestion.Text.Trim(),
+                Difficulty = (byte)numDifficulty.Value,
+                CreatedAt = DateTime.UtcNow
+            };
+            foreach (var opt in options)
+            {
+                question.Options.Add(opt);
+            }
+            _db.Questions.Add(question);
+            await _db.SaveChangesAsync();
+            MessageBox.Show("Saved!");
+        }
+    }
+}

--- a/EduLms.WinForms/TeacherQuestionForm.resx
+++ b/EduLms.WinForms/TeacherQuestionForm.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>


### PR DESCRIPTION
## Summary
- add TeacherQuestionForm to capture questions, difficulty, and options
- populate subject list on form load
- validate inputs and persist questions with options

## Testing
- `dotnet build EduLms.WinForms.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68aef86c79708328b463aabf1a0315dd