### PR TITLE
Add TeacherQuestionForm and login dialog

### DIFF
--- a/EduLms.WinForms/LoginForm.Designer.cs
+++ b/EduLms.WinForms/LoginForm.Designer.cs
@@ -1,0 +1,100 @@
+namespace EduLms.WinForms
+{
+    partial class LoginForm
+    {
+        /// <summary>
+        ///  Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        ///  Clean up any resources being used.
+        /// </summary>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        private void InitializeComponent()
+        {
+            lblEmail = new Label();
+            txtEmail = new TextBox();
+            lblPassword = new Label();
+            txtPassword = new TextBox();
+            btnLogin = new Button();
+            SuspendLayout();
+            // 
+            // lblEmail
+            // 
+            lblEmail.AutoSize = true;
+            lblEmail.Location = new Point(12, 15);
+            lblEmail.Name = "lblEmail";
+            lblEmail.Size = new Size(36, 15);
+            lblEmail.TabIndex = 0;
+            lblEmail.Text = "Email";
+            // 
+            // txtEmail
+            // 
+            txtEmail.Location = new Point(90, 12);
+            txtEmail.Name = "txtEmail";
+            txtEmail.Size = new Size(180, 23);
+            txtEmail.TabIndex = 1;
+            // 
+            // lblPassword
+            // 
+            lblPassword.AutoSize = true;
+            lblPassword.Location = new Point(12, 50);
+            lblPassword.Name = "lblPassword";
+            lblPassword.Size = new Size(57, 15);
+            lblPassword.TabIndex = 2;
+            lblPassword.Text = "Password";
+            // 
+            // txtPassword
+            // 
+            txtPassword.Location = new Point(90, 47);
+            txtPassword.Name = "txtPassword";
+            txtPassword.Size = new Size(180, 23);
+            txtPassword.TabIndex = 3;
+            txtPassword.UseSystemPasswordChar = true;
+            // 
+            // btnLogin
+            // 
+            btnLogin.Location = new Point(195, 85);
+            btnLogin.Name = "btnLogin";
+            btnLogin.Size = new Size(75, 23);
+            btnLogin.TabIndex = 4;
+            btnLogin.Text = "Login";
+            btnLogin.UseVisualStyleBackColor = true;
+            btnLogin.Click += btnLogin_Click;
+            // 
+            // LoginForm
+            // 
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            ClientSize = new Size(284, 121);
+            Controls.Add(btnLogin);
+            Controls.Add(txtPassword);
+            Controls.Add(lblPassword);
+            Controls.Add(txtEmail);
+            Controls.Add(lblEmail);
+            Name = "LoginForm";
+            Text = "Login";
+            ResumeLayout(false);
+            PerformLayout();
+        }
+
+        #endregion
+
+        private Label lblEmail;
+        private TextBox txtEmail;
+        private Label lblPassword;
+        private TextBox txtPassword;
+        private Button btnLogin;
+    }
+}

--- a/EduLms.WinForms/LoginForm.cs
+++ b/EduLms.WinForms/LoginForm.cs
@@ -1,0 +1,37 @@
+using BCrypt.Net;
+using EduLms.Data.Data.Models;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Windows.Forms;
+
+namespace EduLms.WinForms
+{
+    public partial class LoginForm : Form
+    {
+        private readonly EduLmsContext _db;
+        public LoginForm(EduLmsContext db)
+        {
+            InitializeComponent();
+            _db = db;
+        }
+
+        private async void btnLogin_Click(object sender, EventArgs e)
+        {
+            var email = txtEmail.Text.Trim();
+            var password = txtPassword.Text;
+            if (string.IsNullOrWhiteSpace(email) || string.IsNullOrWhiteSpace(password))
+            {
+                MessageBox.Show("Email and password are required.");
+                return;
+            }
+            var user = await _db.Users.AsNoTracking().FirstOrDefaultAsync(u => u.Email == email);
+            if (user == null || !BCrypt.Net.BCrypt.Verify(password, user.PasswordHash))
+            {
+                MessageBox.Show("Invalid credentials.");
+                return;
+            }
+            MessageBox.Show("Login successful!");
+            DialogResult = DialogResult.OK;
+        }
+    }
+}

--- a/EduLms.WinForms/LoginForm.resx
+++ b/EduLms.WinForms/LoginForm.resx
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/EduLms.WinForms/MainForm.Designer.cs
+++ b/EduLms.WinForms/MainForm.Designer.cs
@@ -31,6 +31,7 @@
             dataGridView1 = new DataGridView();
             txtEmail = new TextBox();
             txtName = new TextBox();
+            btnLogin = new Button();
             ((System.ComponentModel.ISupportInitialize)dataGridView1).BeginInit();
             SuspendLayout();
             // 
@@ -57,12 +58,23 @@
             txtName.Size = new Size(100, 23);
             txtName.TabIndex = 2;
             txtName.Text = "FullName";
-            // 
+            //
+            // btnLogin
+            //
+            btnLogin.Location = new Point(101, 100);
+            btnLogin.Name = "btnLogin";
+            btnLogin.Size = new Size(75, 23);
+            btnLogin.TabIndex = 3;
+            btnLogin.Text = "Login";
+            btnLogin.UseVisualStyleBackColor = true;
+            btnLogin.Click += btnLogin_Click;
+            //
             // MainForm
-            // 
+            //
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             ClientSize = new Size(800, 450);
+            Controls.Add(btnLogin);
             Controls.Add(txtName);
             Controls.Add(txtEmail);
             Controls.Add(dataGridView1);
@@ -78,5 +90,6 @@
         private DataGridView dataGridView1;
         private TextBox txtEmail;
         private TextBox txtName;
+        private Button btnLogin;
     }
 }

--- a/EduLms.WinForms/MainForm.cs
+++ b/EduLms.WinForms/MainForm.cs
@@ -43,5 +43,11 @@ namespace EduLms.WinForms
             await _db.SaveChangesAsync();
             MessageBox.Show("Saved!");
         }
+
+        private void btnLogin_Click(object? sender, EventArgs e)
+        {
+            using var frm = new LoginForm(_db);
+            frm.ShowDialog();
+        }
     }
 }

--- a/EduLms.WinForms/Program.cs
+++ b/EduLms.WinForms/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using System.Windows.Forms;
 namespace EduLms.WinForms
 {
     internal static class Program
@@ -22,13 +23,18 @@ namespace EduLms.WinForms
                     services.AddDbContext<EduLmsContext>(opt =>
                         opt.UseSqlServer(cs));
                     // Đăng ký Form dùng DI
+                    services.AddTransient<LoginForm>();
                     services.AddTransient<MainForm>();
                 })
                 .Build();
 
             ApplicationConfiguration.Initialize();
-            var main = host.Services.GetRequiredService<MainForm>();
-            Application.Run(main);
+            var login = host.Services.GetRequiredService<LoginForm>();
+            if (login.ShowDialog() == DialogResult.OK)
+            {
+                var main = host.Services.GetRequiredService<MainForm>();
+                Application.Run(main);
+            }
         }
     }
 }

--- a/EduLms.WinForms/TeacherQuestionForm.Designer.cs
+++ b/EduLms.WinForms/TeacherQuestionForm.Designer.cs
@@ -1,0 +1,103 @@
+namespace EduLms.WinForms
+{
+    partial class TeacherQuestionForm
+    {
+        private System.ComponentModel.IContainer components = null;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        private void InitializeComponent()
+        {
+            cmbSubjects = new ComboBox();
+            txtQuestion = new TextBox();
+            numDifficulty = new NumericUpDown();
+            gridOptions = new DataGridView();
+            btnSave = new Button();
+            var colContent = new DataGridViewTextBoxColumn();
+            var colIsCorrect = new DataGridViewCheckBoxColumn();
+            ((System.ComponentModel.ISupportInitialize)numDifficulty).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)gridOptions).BeginInit();
+            SuspendLayout();
+            //
+            // cmbSubjects
+            //
+            cmbSubjects.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbSubjects.Location = new Point(30, 25);
+            cmbSubjects.Name = "cmbSubjects";
+            cmbSubjects.Size = new Size(200, 23);
+            cmbSubjects.TabIndex = 0;
+            //
+            // txtQuestion
+            //
+            txtQuestion.Location = new Point(30, 65);
+            txtQuestion.Multiline = true;
+            txtQuestion.Name = "txtQuestion";
+            txtQuestion.Size = new Size(400, 60);
+            txtQuestion.TabIndex = 1;
+            //
+            // numDifficulty
+            //
+            numDifficulty.Location = new Point(250, 25);
+            numDifficulty.Name = "numDifficulty";
+            numDifficulty.Size = new Size(120, 23);
+            numDifficulty.TabIndex = 2;
+            //
+            // gridOptions
+            //
+            colContent.HeaderText = "Option";
+            colContent.Name = "colContent";
+            colIsCorrect.HeaderText = "IsCorrect";
+            colIsCorrect.Name = "colIsCorrect";
+            gridOptions.Columns.AddRange(new DataGridViewColumn[] { colContent, colIsCorrect });
+            gridOptions.Location = new Point(30, 140);
+            gridOptions.Name = "gridOptions";
+            gridOptions.Size = new Size(400, 150);
+            gridOptions.TabIndex = 3;
+            //
+            // btnSave
+            //
+            btnSave.Location = new Point(355, 310);
+            btnSave.Name = "btnSave";
+            btnSave.Size = new Size(75, 23);
+            btnSave.TabIndex = 4;
+            btnSave.Text = "Save";
+            btnSave.UseVisualStyleBackColor = true;
+            btnSave.Click += btnSave_Click;
+            //
+            // TeacherQuestionForm
+            //
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            ClientSize = new Size(464, 351);
+            Controls.Add(btnSave);
+            Controls.Add(gridOptions);
+            Controls.Add(numDifficulty);
+            Controls.Add(txtQuestion);
+            Controls.Add(cmbSubjects);
+            Name = "TeacherQuestionForm";
+            Text = "TeacherQuestionForm";
+            Load += TeacherQuestionForm_Load;
+            ((System.ComponentModel.ISupportInitialize)numDifficulty).EndInit();
+            ((System.ComponentModel.ISupportInitialize)gridOptions).EndInit();
+            ResumeLayout(false);
+            PerformLayout();
+        }
+
+        #endregion
+
+        private ComboBox cmbSubjects;
+        private TextBox txtQuestion;
+        private NumericUpDown numDifficulty;
+        private DataGridView gridOptions;
+        private Button btnSave;
+    }
+}

--- a/EduLms.WinForms/TeacherQuestionForm.cs
+++ b/EduLms.WinForms/TeacherQuestionForm.cs
@@ -1,0 +1,77 @@
+using EduLms.Data.Data.Models;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace EduLms.WinForms
+{
+    public partial class TeacherQuestionForm : Form
+    {
+        private readonly EduLmsContext _db;
+        public TeacherQuestionForm(EduLmsContext db)
+        {
+            InitializeComponent();
+            _db = db;
+        }
+
+        private async void TeacherQuestionForm_Load(object sender, EventArgs e)
+        {
+            var subjects = await _db.Subjects.AsNoTracking().ToListAsync();
+            cmbSubjects.DataSource = subjects;
+            cmbSubjects.DisplayMember = nameof(Subject.SubjectName);
+            cmbSubjects.ValueMember = nameof(Subject.SubjectId);
+        }
+
+        private async void btnSave_Click(object sender, EventArgs e)
+        {
+            if (cmbSubjects.SelectedItem is not Subject subject)
+            {
+                MessageBox.Show("Please select a subject.");
+                return;
+            }
+            if (string.IsNullOrWhiteSpace(txtQuestion.Text))
+            {
+                MessageBox.Show("Question text is required.");
+                return;
+            }
+
+            var options = new List<Option>();
+            foreach (DataGridViewRow row in gridOptions.Rows)
+            {
+                if (row.IsNewRow) continue;
+                var content = row.Cells["colContent"].Value?.ToString();
+                var isCorrectObj = row.Cells["colIsCorrect"].Value;
+                var isCorrect = isCorrectObj != null && (bool)isCorrectObj;
+                if (string.IsNullOrWhiteSpace(content))
+                {
+                    MessageBox.Show("All option texts are required.");
+                    return;
+                }
+                options.Add(new Option { Content = content, IsCorrect = isCorrect });
+            }
+
+            if (!options.Any(o => o.IsCorrect))
+            {
+                MessageBox.Show("At least one option must be marked correct.");
+                return;
+            }
+
+            var question = new Question
+            {
+                SubjectId = subject.SubjectId,
+                Content = txtQuestion.Text.Trim(),
+                Difficulty = (byte)numDifficulty.Value,
+                CreatedAt = DateTime.UtcNow
+            };
+            foreach (var opt in options)
+            {
+                question.Options.Add(opt);
+            }
+            _db.Questions.Add(question);
+            await _db.SaveChangesAsync();
+            MessageBox.Show("Saved!");
+        }
+    }
+}

--- a/EduLms.WinForms/TeacherQuestionForm.resx
+++ b/EduLms.WinForms/TeacherQuestionForm.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>


### PR DESCRIPTION
## Summary
- add TeacherQuestionForm to capture questions, difficulty, and options
- add login dialog verifying credentials against database and open via MainForm login button
- show login form first before launching main form

## Testing
- `dotnet build EduLms.WinForms.sln` *(fails: command not found)*
- `apt-get update` *(fails: 403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aef86c79708328b463aabf1a0315dd