### PR TITLE
Add teacher exam creation and question types

### DIFF
--- a/EduLms.WinForms/LoginForm.cs
+++ b/EduLms.WinForms/LoginForm.cs
@@ -9,6 +9,7 @@ namespace EduLms.WinForms
     public partial class LoginForm : Form
     {
         private readonly EduLmsContext _db;
+        public User? LoggedInUser { get; private set; }
         public LoginForm(EduLmsContext db)
         {
             InitializeComponent();
@@ -30,6 +31,7 @@ namespace EduLms.WinForms
                 MessageBox.Show("Invalid credentials.");
                 return;
             }
+            LoggedInUser = user;
             MessageBox.Show("Login successful!");
             DialogResult = DialogResult.OK;
         }

--- a/EduLms.WinForms/MainForm.Designer.cs
+++ b/EduLms.WinForms/MainForm.Designer.cs
@@ -28,68 +28,133 @@
         /// </summary>
         private void InitializeComponent()
         {
-            dataGridView1 = new DataGridView();
-            txtEmail = new TextBox();
-            txtName = new TextBox();
-            btnLogin = new Button();
-            ((System.ComponentModel.ISupportInitialize)dataGridView1).BeginInit();
+            tabManage = new TabControl();
+            tabClasses = new TabPage();
+            gridClasses = new DataGridView();
+            tabSubjects = new TabPage();
+            gridSubjects = new DataGridView();
+            tabScores = new TabPage();
+            gridScores = new DataGridView();
+            btnCreateExam = new Button();
+            tabManage.SuspendLayout();
+            tabClasses.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)gridClasses).BeginInit();
+            tabSubjects.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)gridSubjects).BeginInit();
+            tabScores.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)gridScores).BeginInit();
             SuspendLayout();
-            // 
-            // dataGridView1
-            // 
-            dataGridView1.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            dataGridView1.Location = new Point(44, 180);
-            dataGridView1.Name = "dataGridView1";
-            dataGridView1.Size = new Size(367, 215);
-            dataGridView1.TabIndex = 0;
-            // 
-            // txtEmail
-            // 
-            txtEmail.Location = new Point(239, 56);
-            txtEmail.Name = "txtEmail";
-            txtEmail.Size = new Size(100, 23);
-            txtEmail.TabIndex = 1;
-            txtEmail.Text = "Email";
-            // 
-            // txtName
-            // 
-            txtName.Location = new Point(101, 56);
-            txtName.Name = "txtName";
-            txtName.Size = new Size(100, 23);
-            txtName.TabIndex = 2;
-            txtName.Text = "FullName";
             //
-            // btnLogin
+            // tabManage
             //
-            btnLogin.Location = new Point(101, 100);
-            btnLogin.Name = "btnLogin";
-            btnLogin.Size = new Size(75, 23);
-            btnLogin.TabIndex = 3;
-            btnLogin.Text = "Login";
-            btnLogin.UseVisualStyleBackColor = true;
-            btnLogin.Click += btnLogin_Click;
+            tabManage.Controls.Add(tabClasses);
+            tabManage.Controls.Add(tabSubjects);
+            tabManage.Controls.Add(tabScores);
+            tabManage.Location = new Point(12, 58);
+            tabManage.Name = "tabManage";
+            tabManage.SelectedIndex = 0;
+            tabManage.Size = new Size(776, 380);
+            tabManage.TabIndex = 0;
+            //
+            // tabClasses
+            //
+            tabClasses.Controls.Add(gridClasses);
+            tabClasses.Location = new Point(4, 24);
+            tabClasses.Name = "tabClasses";
+            tabClasses.Padding = new Padding(3);
+            tabClasses.Size = new Size(768, 352);
+            tabClasses.TabIndex = 0;
+            tabClasses.Text = "Classes";
+            tabClasses.UseVisualStyleBackColor = true;
+            //
+            // gridClasses
+            //
+            gridClasses.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            gridClasses.Dock = DockStyle.Fill;
+            gridClasses.Location = new Point(3, 3);
+            gridClasses.Name = "gridClasses";
+            gridClasses.Size = new Size(762, 346);
+            gridClasses.TabIndex = 0;
+            //
+            // tabSubjects
+            //
+            tabSubjects.Controls.Add(gridSubjects);
+            tabSubjects.Location = new Point(4, 24);
+            tabSubjects.Name = "tabSubjects";
+            tabSubjects.Padding = new Padding(3);
+            tabSubjects.Size = new Size(768, 352);
+            tabSubjects.TabIndex = 1;
+            tabSubjects.Text = "Subjects";
+            tabSubjects.UseVisualStyleBackColor = true;
+            //
+            // gridSubjects
+            //
+            gridSubjects.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            gridSubjects.Dock = DockStyle.Fill;
+            gridSubjects.Location = new Point(3, 3);
+            gridSubjects.Name = "gridSubjects";
+            gridSubjects.Size = new Size(762, 346);
+            gridSubjects.TabIndex = 0;
+            //
+            // tabScores
+            //
+            tabScores.Controls.Add(gridScores);
+            tabScores.Location = new Point(4, 24);
+            tabScores.Name = "tabScores";
+            tabScores.Padding = new Padding(3);
+            tabScores.Size = new Size(768, 352);
+            tabScores.TabIndex = 2;
+            tabScores.Text = "Scores";
+            tabScores.UseVisualStyleBackColor = true;
+            //
+            // gridScores
+            //
+            gridScores.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            gridScores.Dock = DockStyle.Fill;
+            gridScores.Location = new Point(3, 3);
+            gridScores.Name = "gridScores";
+            gridScores.Size = new Size(762, 346);
+            gridScores.TabIndex = 0;
+            //
+            // btnCreateExam
+            //
+            btnCreateExam.Location = new Point(12, 12);
+            btnCreateExam.Name = "btnCreateExam";
+            btnCreateExam.Size = new Size(120, 30);
+            btnCreateExam.TabIndex = 1;
+            btnCreateExam.Text = "Create Exam";
+            btnCreateExam.UseVisualStyleBackColor = true;
+            btnCreateExam.Click += btnCreateExam_Click;
             //
             // MainForm
             //
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             ClientSize = new Size(800, 450);
-            Controls.Add(btnLogin);
-            Controls.Add(txtName);
-            Controls.Add(txtEmail);
-            Controls.Add(dataGridView1);
+            Controls.Add(btnCreateExam);
+            Controls.Add(tabManage);
             Name = "MainForm";
-            Text = "MainForm";
-            ((System.ComponentModel.ISupportInitialize)dataGridView1).EndInit();
+            Text = "Teacher Dashboard";
+            Load += MainForm_Load;
+            tabManage.ResumeLayout(false);
+            tabClasses.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)gridClasses).EndInit();
+            tabSubjects.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)gridSubjects).EndInit();
+            tabScores.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)gridScores).EndInit();
             ResumeLayout(false);
-            PerformLayout();
         }
 
         #endregion
 
-        private DataGridView dataGridView1;
-        private TextBox txtEmail;
-        private TextBox txtName;
-        private Button btnLogin;
+        private TabControl tabManage;
+        private TabPage tabClasses;
+        private DataGridView gridClasses;
+        private TabPage tabSubjects;
+        private DataGridView gridSubjects;
+        private TabPage tabScores;
+        private DataGridView gridScores;
+        private Button btnCreateExam;
     }
 }

--- a/EduLms.WinForms/Program.cs
+++ b/EduLms.WinForms/Program.cs
@@ -25,6 +25,7 @@ namespace EduLms.WinForms
                     // Đăng ký Form dùng DI
                     services.AddTransient<LoginForm>();
                     services.AddTransient<MainForm>();
+                    services.AddTransient<StudentForm>();
                 })
                 .Build();
 
@@ -33,11 +34,25 @@ namespace EduLms.WinForms
 
             ApplicationConfiguration.Initialize();
             var login = services.GetRequiredService<LoginForm>();
-            if (login.ShowDialog() == DialogResult.OK)
+            if (login.ShowDialog() == DialogResult.OK && login.LoggedInUser != null)
             {
-                var main = services.GetRequiredService<MainForm>();
-
-                Application.Run(main);
+                var role = login.LoggedInUser.Role;
+                if (string.Equals(role, "Teacher", StringComparison.OrdinalIgnoreCase))
+                {
+                    var main = services.GetRequiredService<MainForm>();
+                    main.LoggedInUser = login.LoggedInUser;
+                    Application.Run(main);
+                }
+                else if (string.Equals(role, "Student", StringComparison.OrdinalIgnoreCase))
+                {
+                    var student = services.GetRequiredService<StudentForm>();
+                    student.LoggedInUser = login.LoggedInUser;
+                    Application.Run(student);
+                }
+                else
+                {
+                    MessageBox.Show($"Role '{role}' is not supported.");
+                }
             }
         }
     }

--- a/EduLms.WinForms/StudentExamTakeForm.Designer.cs
+++ b/EduLms.WinForms/StudentExamTakeForm.Designer.cs
@@ -1,0 +1,81 @@
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace EduLms.WinForms
+{
+    partial class StudentExamTakeForm
+    {
+        private System.ComponentModel.IContainer components = null;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        private void InitializeComponent()
+        {
+            lblInfo = new Label();
+            lblTimer = new Label();
+            btnSubmit = new Button();
+            SuspendLayout();
+            //
+            // lblInfo
+            //
+            lblInfo.AutoSize = true;
+            lblInfo.Location = new Point(12, 9);
+            lblInfo.Name = "lblInfo";
+            lblInfo.Size = new Size(88, 15);
+            lblInfo.TabIndex = 0;
+            lblInfo.Text = "Exam in progress";
+            //
+            // lblTimer
+            //
+            lblTimer.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            lblTimer.AutoSize = true;
+            lblTimer.Location = new Point(776, 9);
+            lblTimer.Name = "lblTimer";
+            lblTimer.Size = new Size(34, 15);
+            lblTimer.TabIndex = 1;
+            lblTimer.Text = "00:00";
+            //
+            // btnSubmit
+            //
+            btnSubmit.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+            btnSubmit.Location = new Point(735, 415);
+            btnSubmit.Name = "btnSubmit";
+            btnSubmit.Size = new Size(75, 23);
+            btnSubmit.TabIndex = 2;
+            btnSubmit.Text = "Submit";
+            btnSubmit.UseVisualStyleBackColor = true;
+            btnSubmit.Click += btnSubmit_Click;
+            //
+            // StudentExamTakeForm
+            //
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            ClientSize = new Size(822, 450);
+            Controls.Add(btnSubmit);
+            Controls.Add(lblTimer);
+            Controls.Add(lblInfo);
+            FormBorderStyle = FormBorderStyle.None;
+            Name = "StudentExamTakeForm";
+            Text = "Exam";
+            TopMost = true;
+            WindowState = FormWindowState.Maximized;
+            ResumeLayout(false);
+            PerformLayout();
+        }
+
+        #endregion
+
+        private Label lblInfo;
+        private Label lblTimer;
+        private Button btnSubmit;
+    }
+}

--- a/EduLms.WinForms/StudentExamTakeForm.cs
+++ b/EduLms.WinForms/StudentExamTakeForm.cs
@@ -1,0 +1,62 @@
+using EduLms.Data.Data.Models;
+using System;
+using System.Windows.Forms;
+
+namespace EduLms.WinForms
+{
+    public partial class StudentExamTakeForm : Form
+    {
+        private readonly EduLmsContext _db;
+        private readonly ExamAttempt _attempt;
+        private Timer _timer;
+        private DateTime _endTime;
+
+        public StudentExamTakeForm(EduLmsContext db, ExamAttempt attempt)
+        {
+            InitializeComponent();
+            _db = db;
+            _attempt = attempt;
+        }
+
+        protected override void OnLoad(EventArgs e)
+        {
+            base.OnLoad(e);
+            _endTime = _attempt.StartedAt.AddMinutes(_attempt.Exam.DurationMinutes);
+            _timer = new Timer();
+            _timer.Interval = 1000;
+            _timer.Tick += Timer_Tick;
+            _timer.Start();
+            UpdateTimer();
+        }
+
+        private void Timer_Tick(object? sender, EventArgs e)
+        {
+            UpdateTimer();
+            if (DateTime.UtcNow >= _endTime)
+            {
+                SubmitAttempt();
+            }
+        }
+
+        private void UpdateTimer()
+        {
+            var remaining = _endTime - DateTime.UtcNow;
+            if (remaining < TimeSpan.Zero) remaining = TimeSpan.Zero;
+            lblTimer.Text = remaining.ToString("mm':'ss");
+        }
+
+        private void btnSubmit_Click(object sender, EventArgs e)
+        {
+            SubmitAttempt();
+        }
+
+        private void SubmitAttempt()
+        {
+            _timer.Stop();
+            _attempt.SubmittedAt = DateTime.UtcNow;
+            _attempt.Status = "Submitted";
+            _db.SaveChanges();
+            Close();
+        }
+    }
+}

--- a/EduLms.WinForms/StudentExamTakeForm.resx
+++ b/EduLms.WinForms/StudentExamTakeForm.resx
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, ...</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, ...</value>
+  </resheader>
+</root>

--- a/EduLms.WinForms/StudentForm.Designer.cs
+++ b/EduLms.WinForms/StudentForm.Designer.cs
@@ -1,0 +1,75 @@
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace EduLms.WinForms
+{
+    partial class StudentForm
+    {
+        /// <summary>
+        ///  Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        ///  Clean up any resources being used.
+        /// </summary>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        private void InitializeComponent()
+        {
+            dgvExams = new DataGridView();
+            btnStart = new Button();
+            SuspendLayout();
+            //
+            // dgvExams
+            //
+            dgvExams.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
+            dgvExams.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            dgvExams.Location = new Point(12, 12);
+            dgvExams.MultiSelect = false;
+            dgvExams.Name = "dgvExams";
+            dgvExams.RowTemplate.Height = 25;
+            dgvExams.SelectionMode = DataGridViewSelectionMode.FullRowSelect;
+            dgvExams.Size = new Size(560, 300);
+            dgvExams.TabIndex = 0;
+            //
+            // btnStart
+            //
+            btnStart.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+            btnStart.Location = new Point(497, 318);
+            btnStart.Name = "btnStart";
+            btnStart.Size = new Size(75, 23);
+            btnStart.TabIndex = 1;
+            btnStart.Text = "Start";
+            btnStart.UseVisualStyleBackColor = true;
+            btnStart.Click += btnStart_Click;
+            //
+            // StudentForm
+            //
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            ClientSize = new Size(584, 361);
+            Controls.Add(btnStart);
+            Controls.Add(dgvExams);
+            Name = "StudentForm";
+            Text = "My Exams";
+            Load += StudentForm_Load;
+            ResumeLayout(false);
+        }
+
+        #endregion
+
+        private DataGridView dgvExams;
+        private Button btnStart;
+    }
+}
+

--- a/EduLms.WinForms/StudentForm.cs
+++ b/EduLms.WinForms/StudentForm.cs
@@ -1,0 +1,86 @@
+using EduLms.Data.Data.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.VisualBasic;
+using System;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace EduLms.WinForms
+{
+    public partial class StudentForm : Form
+    {
+        private readonly EduLmsContext _db;
+        public User? LoggedInUser { get; set; }
+        public StudentForm(EduLmsContext db)
+        {
+            InitializeComponent();
+            _db = db;
+        }
+
+        private void StudentForm_Load(object sender, EventArgs e)
+        {
+            if (LoggedInUser == null) return;
+
+            var now = DateTime.UtcNow;
+
+            var exams = _db.ExamStudentAssignments
+                .Include(a => a.Exam)
+                .ThenInclude(e => e.Subject)
+                .Where(a => a.StudentId == LoggedInUser.UserId
+                    && (a.Exam.StartAt == null || a.Exam.StartAt <= now)
+                    && (a.Exam.EndAt == null || a.Exam.EndAt >= now))
+                .Select(a => new
+                {
+                    a.Exam.ExamId,
+                    a.Exam.Title,
+                    Subject = a.Exam.Subject.Name,
+                    a.Exam.StartAt,
+                    a.Exam.EndAt
+                })
+                .ToList();
+
+            dgvExams.DataSource = exams;
+        }
+
+        private void btnStart_Click(object sender, EventArgs e)
+        {
+            if (dgvExams.CurrentRow == null || LoggedInUser == null) return;
+
+            var examId = (int)dgvExams.CurrentRow.Cells["ExamId"].Value;
+
+            var input = Interaction.InputBox("Enter paper code", "Start Exam", "");
+            if (string.IsNullOrWhiteSpace(input)) return;
+
+            var paper = _db.ExamPapers.FirstOrDefault(p => p.ExamId == examId && p.PaperCode == input);
+            if (paper == null)
+            {
+                MessageBox.Show("Invalid paper code");
+                return;
+            }
+
+            var attempt = _db.ExamAttempts
+                .Include(a => a.Exam)
+                .FirstOrDefault(a => a.ExamId == examId && a.StudentId == LoggedInUser.UserId);
+            if (attempt == null)
+            {
+                attempt = new ExamAttempt
+                {
+                    ExamId = examId,
+                    StudentId = LoggedInUser.UserId,
+                    PaperId = paper.PaperId,
+                    StartedAt = DateTime.UtcNow,
+                    Status = "InProgress"
+                };
+                _db.ExamAttempts.Add(attempt);
+                _db.SaveChanges();
+                _db.Entry(attempt).Reference(a => a.Exam).Load();
+            }
+
+            using var examForm = new StudentExamTakeForm(_db, attempt);
+            Hide();
+            examForm.ShowDialog();
+            Show();
+        }
+    }
+}
+

--- a/EduLms.WinForms/StudentForm.resx
+++ b/EduLms.WinForms/StudentForm.resx
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>
+

--- a/EduLms.WinForms/TeacherExamForm.Designer.cs
+++ b/EduLms.WinForms/TeacherExamForm.Designer.cs
@@ -1,0 +1,218 @@
+namespace EduLms.WinForms
+{
+    partial class TeacherExamForm
+    {
+        private System.ComponentModel.IContainer components = null;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        private void InitializeComponent()
+        {
+            lblTitle = new Label();
+            txtTitle = new TextBox();
+            lblSubject = new Label();
+            cmbSubject = new ComboBox();
+            lblDuration = new Label();
+            numDuration = new NumericUpDown();
+            lblStart = new Label();
+            dtStart = new DateTimePicker();
+            lblEnd = new Label();
+            dtEnd = new DateTimePicker();
+            lblMaxAttempts = new Label();
+            numMaxAttempts = new NumericUpDown();
+            chkShuffle = new CheckBox();
+            btnAddQuestion = new Button();
+            gridQuestions = new DataGridView();
+            btnSave = new Button();
+            ((System.ComponentModel.ISupportInitialize)numDuration).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)numMaxAttempts).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)gridQuestions).BeginInit();
+            SuspendLayout();
+            //
+            // lblTitle
+            //
+            lblTitle.AutoSize = true;
+            lblTitle.Location = new Point(30, 20);
+            lblTitle.Name = "lblTitle";
+            lblTitle.Size = new Size(29, 15);
+            lblTitle.Text = "Title";
+            //
+            // txtTitle
+            //
+            txtTitle.Location = new Point(150, 17);
+            txtTitle.Name = "txtTitle";
+            txtTitle.Size = new Size(200, 23);
+            //
+            // lblSubject
+            //
+            lblSubject.AutoSize = true;
+            lblSubject.Location = new Point(30, 60);
+            lblSubject.Name = "lblSubject";
+            lblSubject.Size = new Size(45, 15);
+            lblSubject.Text = "Subject";
+            //
+            // cmbSubject
+            //
+            cmbSubject.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbSubject.Location = new Point(150, 57);
+            cmbSubject.Name = "cmbSubject";
+            cmbSubject.Size = new Size(200, 23);
+            //
+            // lblDuration
+            //
+            lblDuration.AutoSize = true;
+            lblDuration.Location = new Point(30, 100);
+            lblDuration.Name = "lblDuration";
+            lblDuration.Size = new Size(94, 15);
+            lblDuration.Text = "Duration (mins)";
+            //
+            // numDuration
+            //
+            numDuration.Location = new Point(150, 98);
+            numDuration.Maximum = new decimal(new int[] { 1000, 0, 0, 0 });
+            numDuration.Name = "numDuration";
+            numDuration.Size = new Size(120, 23);
+            //
+            // lblStart
+            //
+            lblStart.AutoSize = true;
+            lblStart.Location = new Point(30, 140);
+            lblStart.Name = "lblStart";
+            lblStart.Size = new Size(47, 15);
+            lblStart.Text = "Start at";
+            //
+            // dtStart
+            //
+            dtStart.CustomFormat = "dd/MM/yyyy HH:mm";
+            dtStart.Format = DateTimePickerFormat.Custom;
+            dtStart.Location = new Point(150, 137);
+            dtStart.Name = "dtStart";
+            dtStart.ShowCheckBox = true;
+            dtStart.Size = new Size(200, 23);
+            //
+            // lblEnd
+            //
+            lblEnd.AutoSize = true;
+            lblEnd.Location = new Point(30, 180);
+            lblEnd.Name = "lblEnd";
+            lblEnd.Size = new Size(43, 15);
+            lblEnd.Text = "End at";
+            //
+            // dtEnd
+            //
+            dtEnd.CustomFormat = "dd/MM/yyyy HH:mm";
+            dtEnd.Format = DateTimePickerFormat.Custom;
+            dtEnd.Location = new Point(150, 177);
+            dtEnd.Name = "dtEnd";
+            dtEnd.ShowCheckBox = true;
+            dtEnd.Size = new Size(200, 23);
+            //
+            // lblMaxAttempts
+            //
+            lblMaxAttempts.AutoSize = true;
+            lblMaxAttempts.Location = new Point(30, 220);
+            lblMaxAttempts.Name = "lblMaxAttempts";
+            lblMaxAttempts.Size = new Size(80, 15);
+            lblMaxAttempts.Text = "Max Attempts";
+            //
+            // numMaxAttempts
+            //
+            numMaxAttempts.Location = new Point(150, 218);
+            numMaxAttempts.Maximum = new decimal(new int[] { 10, 0, 0, 0 });
+            numMaxAttempts.Minimum = new decimal(new int[] { 1, 0, 0, 0 });
+            numMaxAttempts.Name = "numMaxAttempts";
+            numMaxAttempts.Size = new Size(120, 23);
+            numMaxAttempts.Value = new decimal(new int[] { 1, 0, 0, 0 });
+            //
+            // chkShuffle
+            //
+            chkShuffle.AutoSize = true;
+            chkShuffle.Location = new Point(150, 255);
+            chkShuffle.Name = "chkShuffle";
+            chkShuffle.Size = new Size(106, 19);
+            chkShuffle.Text = "Shuffle options";
+            chkShuffle.UseVisualStyleBackColor = true;
+            //
+            // btnAddQuestion
+            //
+            btnAddQuestion.Location = new Point(150, 290);
+            btnAddQuestion.Name = "btnAddQuestion";
+            btnAddQuestion.Size = new Size(120, 23);
+            btnAddQuestion.TabIndex = 8;
+            btnAddQuestion.Text = "Add Question";
+            btnAddQuestion.UseVisualStyleBackColor = true;
+            btnAddQuestion.Click += btnAddQuestion_Click;
+            //
+            // gridQuestions
+            //
+            gridQuestions.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            gridQuestions.Location = new Point(30, 330);
+            gridQuestions.Name = "gridQuestions";
+            gridQuestions.Size = new Size(540, 150);
+            gridQuestions.TabIndex = 9;
+            //
+            // btnSave
+            //
+            btnSave.Location = new Point(150, 500);
+            btnSave.Name = "btnSave";
+            btnSave.Size = new Size(75, 23);
+            btnSave.Text = "Save";
+            btnSave.UseVisualStyleBackColor = true;
+            btnSave.Click += btnSave_Click;
+            //
+            // TeacherExamForm
+            //
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            ClientSize = new Size(600, 540);
+            Controls.Add(btnSave);
+            Controls.Add(gridQuestions);
+            Controls.Add(btnAddQuestion);
+            Controls.Add(chkShuffle);
+            Controls.Add(numMaxAttempts);
+            Controls.Add(lblMaxAttempts);
+            Controls.Add(dtEnd);
+            Controls.Add(lblEnd);
+            Controls.Add(dtStart);
+            Controls.Add(lblStart);
+            Controls.Add(numDuration);
+            Controls.Add(lblDuration);
+            Controls.Add(cmbSubject);
+            Controls.Add(lblSubject);
+            Controls.Add(txtTitle);
+            Controls.Add(lblTitle);
+            Name = "TeacherExamForm";
+            Text = "Create Exam";
+            Load += TeacherExamForm_Load;
+            ((System.ComponentModel.ISupportInitialize)numDuration).EndInit();
+            ((System.ComponentModel.ISupportInitialize)numMaxAttempts).EndInit();
+            ((System.ComponentModel.ISupportInitialize)gridQuestions).EndInit();
+            ResumeLayout(false);
+            PerformLayout();
+        }
+
+        private Label lblTitle;
+        private TextBox txtTitle;
+        private Label lblSubject;
+        private ComboBox cmbSubject;
+        private Label lblDuration;
+        private NumericUpDown numDuration;
+        private Label lblStart;
+        private DateTimePicker dtStart;
+        private Label lblEnd;
+        private DateTimePicker dtEnd;
+        private Label lblMaxAttempts;
+        private NumericUpDown numMaxAttempts;
+        private CheckBox chkShuffle;
+        private Button btnAddQuestion;
+        private DataGridView gridQuestions;
+        private Button btnSave;
+    }
+}

--- a/EduLms.WinForms/TeacherExamForm.cs
+++ b/EduLms.WinForms/TeacherExamForm.cs
@@ -1,0 +1,99 @@
+using EduLms.Data.Data.Models;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace EduLms.WinForms
+{
+    public partial class TeacherExamForm : Form
+    {
+        private readonly EduLmsContext _db;
+        private readonly User _teacher;
+        private readonly List<Question> _questions = new();
+        public TeacherExamForm(EduLmsContext db, User teacher)
+        {
+            InitializeComponent();
+            _db = db;
+            _teacher = teacher;
+        }
+
+        private async void TeacherExamForm_Load(object sender, EventArgs e)
+        {
+            var subjects = await _db.Subjects.AsNoTracking().ToListAsync();
+            cmbSubject.DataSource = subjects;
+            cmbSubject.DisplayMember = nameof(Subject.SubjectName);
+            cmbSubject.ValueMember = nameof(Subject.SubjectId);
+            gridQuestions.AutoGenerateColumns = true;
+            gridQuestions.DataSource = _questions;
+        }
+
+        private async void btnSave_Click(object sender, EventArgs e)
+        {
+            if (cmbSubject.SelectedItem is not Subject subject)
+            {
+                MessageBox.Show("Please select a subject.");
+                return;
+            }
+            if (string.IsNullOrWhiteSpace(txtTitle.Text))
+            {
+                MessageBox.Show("Title is required.");
+                return;
+            }
+            if (!_questions.Any())
+            {
+                MessageBox.Show("Please add at least one question.");
+                return;
+            }
+            var exam = new Exam
+            {
+                Title = txtTitle.Text.Trim(),
+                SubjectId = subject.SubjectId,
+                DurationMinutes = (int)numDuration.Value,
+                StartAt = dtStart.Checked ? dtStart.Value : null,
+                EndAt = dtEnd.Checked ? dtEnd.Value : null,
+                CreatedByTeacherId = _teacher.UserId,
+                MaxAttempts = (int)numMaxAttempts.Value,
+                ShuffleOptions = chkShuffle.Checked,
+                CreatedAt = DateTime.UtcNow
+            };
+            _db.Exams.Add(exam);
+            await _db.SaveChangesAsync();
+
+            var paper = new ExamPaper
+            {
+                ExamId = exam.ExamId,
+                PaperCode = "1",
+                IsActive = true
+            };
+            _db.ExamPapers.Add(paper);
+            await _db.SaveChangesAsync();
+
+            int ordinal = 1;
+            foreach (var q in _questions)
+            {
+                _db.ExamPaperQuestions.Add(new ExamPaperQuestion
+                {
+                    PaperId = paper.PaperId,
+                    QuestionId = q.QuestionId,
+                    Ordinal = ordinal++
+                });
+            }
+            await _db.SaveChangesAsync();
+
+            MessageBox.Show("Exam saved!");
+        }
+
+        private void btnAddQuestion_Click(object sender, EventArgs e)
+        {
+            using var frm = new TeacherQuestionForm(_db);
+            if (frm.ShowDialog() == DialogResult.OK && frm.CreatedQuestion != null)
+            {
+                _questions.Add(frm.CreatedQuestion);
+                gridQuestions.DataSource = null;
+                gridQuestions.DataSource = _questions.Select(q => new { q.QuestionId, q.Content }).ToList();
+            }
+        }
+    }
+}

--- a/EduLms.WinForms/TeacherExamForm.resx
+++ b/EduLms.WinForms/TeacherExamForm.resx
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/EduLms.WinForms/TeacherQuestionForm.Designer.cs
+++ b/EduLms.WinForms/TeacherQuestionForm.Designer.cs
@@ -20,11 +20,15 @@ namespace EduLms.WinForms
             cmbSubjects = new ComboBox();
             txtQuestion = new TextBox();
             numDifficulty = new NumericUpDown();
+            cmbType = new ComboBox();
+            btnImage = new Button();
+            picQuestion = new PictureBox();
             gridOptions = new DataGridView();
             btnSave = new Button();
             var colContent = new DataGridViewTextBoxColumn();
             var colIsCorrect = new DataGridViewCheckBoxColumn();
             ((System.ComponentModel.ISupportInitialize)numDifficulty).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)picQuestion).BeginInit();
             ((System.ComponentModel.ISupportInitialize)gridOptions).BeginInit();
             SuspendLayout();
             //
@@ -51,6 +55,35 @@ namespace EduLms.WinForms
             numDifficulty.Size = new Size(120, 23);
             numDifficulty.TabIndex = 2;
             //
+            // cmbType
+            //
+            cmbType.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbType.Location = new Point(390, 25);
+            cmbType.Name = "cmbType";
+            cmbType.Size = new Size(140, 23);
+            cmbType.TabIndex = 3;
+            cmbType.SelectedIndexChanged += cmbType_SelectedIndexChanged;
+            //
+            // btnImage
+            //
+            btnImage.Location = new Point(440, 65);
+            btnImage.Name = "btnImage";
+            btnImage.Size = new Size(90, 23);
+            btnImage.TabIndex = 4;
+            btnImage.Text = "Load Image";
+            btnImage.UseVisualStyleBackColor = true;
+            btnImage.Click += btnImage_Click;
+            //
+            // picQuestion
+            //
+            picQuestion.BorderStyle = BorderStyle.FixedSingle;
+            picQuestion.Location = new Point(440, 94);
+            picQuestion.Name = "picQuestion";
+            picQuestion.Size = new Size(140, 120);
+            picQuestion.SizeMode = PictureBoxSizeMode.Zoom;
+            picQuestion.TabIndex = 5;
+            picQuestion.TabStop = false;
+            //
             // gridOptions
             //
             colContent.HeaderText = "Option";
@@ -58,17 +91,17 @@ namespace EduLms.WinForms
             colIsCorrect.HeaderText = "IsCorrect";
             colIsCorrect.Name = "colIsCorrect";
             gridOptions.Columns.AddRange(new DataGridViewColumn[] { colContent, colIsCorrect });
-            gridOptions.Location = new Point(30, 140);
+            gridOptions.Location = new Point(30, 160);
             gridOptions.Name = "gridOptions";
             gridOptions.Size = new Size(400, 150);
-            gridOptions.TabIndex = 3;
+            gridOptions.TabIndex = 6;
             //
             // btnSave
             //
-            btnSave.Location = new Point(355, 310);
+            btnSave.Location = new Point(505, 315);
             btnSave.Name = "btnSave";
             btnSave.Size = new Size(75, 23);
-            btnSave.TabIndex = 4;
+            btnSave.TabIndex = 7;
             btnSave.Text = "Save";
             btnSave.UseVisualStyleBackColor = true;
             btnSave.Click += btnSave_Click;
@@ -77,16 +110,20 @@ namespace EduLms.WinForms
             //
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
-            ClientSize = new Size(464, 351);
+            ClientSize = new Size(594, 361);
             Controls.Add(btnSave);
             Controls.Add(gridOptions);
+            Controls.Add(picQuestion);
+            Controls.Add(btnImage);
+            Controls.Add(cmbType);
             Controls.Add(numDifficulty);
             Controls.Add(txtQuestion);
             Controls.Add(cmbSubjects);
             Name = "TeacherQuestionForm";
-            Text = "TeacherQuestionForm";
+            Text = "Question";
             Load += TeacherQuestionForm_Load;
             ((System.ComponentModel.ISupportInitialize)numDifficulty).EndInit();
+            ((System.ComponentModel.ISupportInitialize)picQuestion).EndInit();
             ((System.ComponentModel.ISupportInitialize)gridOptions).EndInit();
             ResumeLayout(false);
             PerformLayout();
@@ -97,6 +134,9 @@ namespace EduLms.WinForms
         private ComboBox cmbSubjects;
         private TextBox txtQuestion;
         private NumericUpDown numDifficulty;
+        private ComboBox cmbType;
+        private Button btnImage;
+        private PictureBox picQuestion;
         private DataGridView gridOptions;
         private Button btnSave;
     }


### PR DESCRIPTION
## Summary
- Show classes, subjects and scores in teacher dashboard with exam creation entry point
- Support text, image, essay and multi/single choice questions in creation form
- Allow teachers to compile exams with selected questions and persist an initial paper

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68af1d27552c83288835ee56daa9b95c